### PR TITLE
Initial version of custom item elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/workspace.xml
+node_modules
+bower_components

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: node_js
+node_js: node
+
+# work around a Chrome startup crash issue:
+#   https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356339798
+#   https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356362524
+sudo: required
+addons:
+  firefox: latest
+before_script:
+- npm install -g polymer-cli
+- polymer install
+
+script:
+- xvfb-run polymer test

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -135,3 +135,9 @@ Custom property                 | Description                                   
 `--spine-item-body-main-cell`   | Mixin applied to a cell that contains the the elements placed into `spine-item-body` | `{}`
 `--spine-item-body-before-cell` | Mixin applied to a cell that contains the `before` slot | `{}`
 `--spine-item-body-after-cell`  | Mixin applied to a cell that contains the `after` slot  | `{}`
+
+# License
+
+Apache License
+
+Version 2.0, January 2004

--- a/README.md
+++ b/README.md
@@ -1,2 +1,137 @@
-# spine-item-elements
-A collection of custom special purpose item elements that can be used on a par with `paper-item`
+# Spine Item Elements
+
+A set of custom special purpose item elements that can be used inside `paper-listbox` on a par with 
+`paper-item`. Here is a list of elements in this package:
+- `spine-header-item` — an unselectable item with a configurable style which can be used as a 
+  header in menu-like list boxes.
+- `spine-link-item` — similar to `paper-item`, but it navigates to the specified URL when tapped
+  or clicked.
+- `spine-separator-item` — an unselectable item that displays a horizontal line, which can be used
+  to visually separate groups of items in `paper-listbox`.
+- `spine-item-body` — can be placed inside of `paper-item` or `sping-link-item` to display a 
+  typical menu/list item layout with optional left and right cells (where item icons are typically 
+  displayed) and a number of content lines.
+  
+Below is a documentation on each of these elements.
+
+## `spine-header-item`
+
+`spine-header-item` can be used inside `paper-listbox` among its children to display a
+non-selectable item that will serve as a heading for the items that follow it in the list.
+Similar to `paper-item`, you can place arbitrary content as its child nodes.
+
+Here's a list of CSS mixins that can be used for customizing `spine-header-item`:
+
+Custom property       | Description                  | Default
+----------------------|------------------------------|--------
+`--spine-header-item` | Mixin applied to the element | `{}`
+
+## `spine-link-item`
+
+`spine-link-item` can be placed into `paper-listbox` to display an item that navigates to the
+specified URL when it is clicked or tapped. Use the `href` attribute to specify the URL that should
+be navigated to when this item is clicked or tapped.
+
+Example:
+```
+<paper-listbox>
+  <spine-link-item href="/settings">
+    Settings
+  </spine-link-item>
+  <spine-link-item href="/settings/notifications">
+    Notifications
+  </proljwc-link-item>
+  <spine-link-item href="/settings/security">
+    Security
+  </proljwc-link-item>
+</paper-listbox>
+```
+
+Elements placed in `spine-link-item` are laid out with a horizontal flow layout by default.
+You can change this using the `--spine-link-item-content-container` mixin.
+
+The focused, selected and hovered states result in a `::before` pseudo element to be included, which
+is laid out to fill the entire element under the `spine-link-item`'s content. You can use the
+`--spine-link-item-hovered-before`,
+`--spine-link-item-selected-before`, and `--spine-link-item-focused-before` CSS variables to
+highlight the background in these states.
+
+Here's a list of CSS variables and mixins for customizing `spine-link-item`:
+
+Custom property                       | Description                                   | Default
+--------------------------------------|-----------------------------------------------|----------
+`--spine-link-item`                   | Mixin applied to `spine-link-item`            | `{}`
+`--spine-link-item-content-container` | Mixin applied to the item's content container | `{}`
+`--spine-link-item-min-height`        | Minimum height for the item                   | `48px`
+`--spine-link-item-disabled`          | Mixin applied to the item when it is disabled | `{}`
+`--spine-link-item-hovered`           | Mixin applied to the item when it is hovered  | `{}`
+`--spine-link-item-hovered-before`    | Mixin for hovered item's background layer     | `{}`
+`--spine-link-item-selected`          | Mixin applied to the item when it is selected | `{}`
+`--spine-link-item-selected-before`   | Mixin for elected item's background layer     | `{}`
+`--spine-link-item-focused`           | Mixin applied to the item when it is focused  | `{}`
+`--spine-link-item-focused-before`    | Mixin for focused item's background layer     | `{}`
+
+## `spine-separator-item`
+
+`spine-separator-item` can be used inside `paper-listbox` among its children to separate them into
+logical groups. It is a non-selectable item that displays a horizontal line whose style can be 
+customized.
+
+Here's a list of CSS variables that can be used for customizing `spine-separator-item`:
+
+Custom property                       | Description                                                              | Default
+--------------------------------------|--------------------------------------------------------------------------|----------
+`--spine-separator-item-vert-padding` | A distance from the separator line to the element's top and bottom edges | `8px`
+`--spine-separator-item-line`         | A CSS border-like declaration that identifies the separator line's style, e.g. `1px dotted gray` | `1px solid var(--light-theme-divider-color)`
+
+## `spine-item-body`
+
+`spine-item-body` can be placed into `paper-item` and `spine-link-item` to set up a typical item
+layout, where you can specify a multi line content as well as custom content on item's sides
+(typically displaying items).
+
+A component has two slots:
+- `before`: can be used to place a custom content in a left side of the item;
+- `after`: can be used to place a custom content in a right side of the item.
+
+You can place several child elements, which will distribute them vertically inside an item's area.
+Specifying a `secondary` attribute for any of these elements will apply the "secondary" text style
+(having a gray color by default) to the respective element.
+
+Example:
+```
+<paper-listbox>
+  <paper-item on-tap="handleCreateItemTap">
+    <spine-item-body>
+      <iron-icon slot="before" icon="custom:create_item"></iron-icon>
+      Create item...
+    <spine-item-body>
+  </paper-item>
+
+  <spine-link-item href="/settings">
+    <spine-item-body>
+      <iron-icon slot="before" icon="custom:settings"></iron-icon>
+      <div>Settings</div>
+      <div secondary>Displays general settings</div>
+    </spine-item-body>
+  </spine-link-item>
+
+  <spine-link-item href="/notifications">
+    <spine-item-body>
+      <iron-icon slot="before" icon="custom:notifications"></iron-icon>
+      <div>Notifications</div>
+      <div slot="after">
+        [[noOfNotifications]]
+      </div>
+    </spine-item-body>
+  </spine-link-item>
+</paper-listbox>
+```
+
+Here's a list of CSS mixins that can be used for customizing `spine-item-body`:
+
+Custom property                 | Description                                             | Default
+--------------------------------|---------------------------------------------------------|----------
+`--spine-item-body-main-cell`   | Mixin applied to a cell that contains the the elements placed into `spine-item-body` | `{}`
+`--spine-item-body-before-cell` | Mixin applied to a cell that contains the `before` slot | `{}`
+`--spine-item-body-after-cell`  | Mixin applied to a cell that contains the `after` slot  | `{}`

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,25 @@
+{
+  "name": "spine-item-elements",
+  "description": "A set of custom special purpose item elements that can be used on a par with `paper-item`",
+  "keywords": [
+    "web-components",
+    "web-component",
+    "polymer",
+    "avatar"
+  ],
+  "main": "spine-avatar.html",
+  "dependencies": {
+    "polymer": "Polymer/polymer#^2.0.0",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#^2.0.0",
+    "iron-behaviors": "^2.1.1"
+  },
+  "devDependencies": {
+    "iron-doc-viewer": "PolymerElements/iron-doc-viewer#^2.0.0",
+    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",
+    "web-component-tester": "Polymer/web-component-tester#^6.0.0",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
+  },
+  "resolutions": {
+    "polymer": "^2.0.0"
+  }
+}

--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "iron-doc-viewer": "PolymerElements/iron-doc-viewer#^2.0.0",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",
-    "web-component-tester": "Polymer/web-component-tester#^6.0.0",
+    "web-component-tester": "Polymer/web-component-tester#^6.5.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0",
     "paper-listbox": "^2.1.0",
     "iron-icon": "^2.1.0",

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,10 @@
     "iron-doc-viewer": "PolymerElements/iron-doc-viewer#^2.0.0",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",
     "web-component-tester": "Polymer/web-component-tester#^6.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0",
+    "paper-listbox": "^2.1.0",
+    "iron-icon": "^2.1.0",
+    "iron-icons": "^2.1.1"
   },
   "resolutions": {
     "polymer": "^2.0.0"

--- a/bower.json
+++ b/bower.json
@@ -5,9 +5,14 @@
     "web-components",
     "web-component",
     "polymer",
-    "avatar"
+    "item"
   ],
-  "main": "spine-avatar.html",
+  "main": [
+    "spine-header-item.html",
+    "spine-link-item.html",
+    "spine-separator-item.html",
+    "spine-item-body.html"
+  ],
   "dependencies": {
     "polymer": "Polymer/polymer#^2.0.0",
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^2.0.0",

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+  <title>Spine item elements demo</title>
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
+  <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
+  <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+  <link rel="import" href="../../iron-icons/iron-icons.html">
+  <link rel="import" href="../../iron-icon/iron-icon.html">
+  <link rel="import" href="../../paper-listbox/paper-listbox.html">
+  <link rel="import" href="../spine-header-item.html">
+  <link rel="import" href="../spine-link-item.html">
+  <link rel="import" href="../spine-separator-item.html">
+  <link rel="import" href="../spine-item-body.html">
+
+  <custom-style>
+    <style is="custom-style" include="demo-pages-shared-styles">
+      .menu {
+        border: 1px solid gray;
+        --spine-item-body-before-cell: {
+          padding-right: 8px;
+        }
+      }
+    </style>
+  </custom-style>
+</head>
+<body>
+<div class="vertical-section-container centered">
+
+  <h3>Simple menu</h3>
+  <demo-snippet>
+    <template>
+      <paper-listbox class="menu">
+        <spine-header-item>spine-item-elements</spine-header-item>
+
+        <spine-link-item href="https://github.com/SpineElements/spine-item-elements">
+          <spine-item-body>
+            <iron-icon slot="before" icon="star"></iron-icon>
+            Overview
+          </spine-item-body>
+        </spine-link-item>
+        <spine-link-item href="https://github.com/SpineElements/spine-item-elements/blob/master/spine-header-item.html">
+          <spine-item-body>
+            <iron-icon slot="before" icon="chevron-right"></iron-icon>
+            spine-header-item
+          </spine-item-body>
+        </spine-link-item>
+        <spine-link-item href="https://github.com/SpineElements/spine-item-elements/blob/master/spine-link-item.html">
+          <spine-item-body>
+            <iron-icon slot="before" icon="chevron-right"></iron-icon>
+            spine-link-item
+          </spine-item-body>
+        </spine-link-item>
+        <spine-link-item href="https://github.com/SpineElements/spine-item-elements/blob/master/spine-separator-item.html">
+          <spine-item-body>
+            <iron-icon slot="before" icon="chevron-right"></iron-icon>
+            spine-separator-item
+          </spine-item-body>
+        </spine-link-item>
+        <spine-link-item href="https://github.com/SpineElements/spine-item-elements/blob/master/spine-item-body.html">
+          <spine-item-body>
+            <iron-icon slot="before" icon="chevron-right"></iron-icon>
+            spine-item-body
+          </spine-item-body>
+        </spine-link-item>
+
+        <spine-separator-item></spine-separator-item>
+
+        <spine-header-item>Other elements</spine-header-item>
+
+        <spine-link-item href="https://github.com/SpineElements/spine-avatar">
+          <spine-item-body>
+            <iron-icon slot="before" icon="star"></iron-icon>
+            spine-avatar
+          </spine-item-body>
+        </spine-link-item>
+        <spine-link-item href="https://github.com/SpineElements/spine-badge">
+          <spine-item-body>
+            <iron-icon slot="before" icon="star"></iron-icon>
+            spine-badge
+          </spine-item-body>
+        </spine-link-item>
+
+      </paper-listbox>
+    </template>
+  </demo-snippet>
+
+
+</div>
+</body>
+</html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -90,7 +90,6 @@
     </template>
   </demo-snippet>
 
-
 </div>
 </body>
 </html>

--- a/spine-abstract-item.html
+++ b/spine-abstract-item.html
@@ -1,0 +1,34 @@
+<!--
+  ~ Copyright (c) 2000-2018 TeamDev Ltd. All rights reserved.
+  ~ TeamDev PROPRIETARY and CONFIDENTIAL.
+  ~ Use is subject to license terms.
+  -->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="../iron-behaviors/iron-control-state.html">
+<link rel="import" href="../iron-behaviors/iron-button-state.html">
+
+<dom-module id="spine-abstract-item">
+  <script>
+    /**
+     * Defines a base class for custom item elements that complement the standard `paper-item`
+     * component for various usage scenarios.
+     */
+    class SpineAbstractItem extends Polymer.mixinBehaviors([
+      Polymer.IronButtonState,
+      Polymer.IronControlState
+    ], Polymer.Element) {
+      _getAriaRole() {
+        // see ARIA roles here: https://www.w3.org/TR/wai-aria-1.1/#role_definitions
+        return 'option';
+      }
+
+      connectedCallback() {
+        super.connectedCallback();
+        this._ensureAttribute('tabindex', '0');
+        this._ensureAttribute('role', this._getAriaRole());
+      }
+    }
+  </script>
+</dom-module>

--- a/spine-header-item.html
+++ b/spine-header-item.html
@@ -1,0 +1,63 @@
+<!--
+  ~ Copyright (c) 2000-2018 TeamDev Ltd. All rights reserved.
+  ~ TeamDev PROPRIETARY and CONFIDENTIAL.
+  ~ Use is subject to license terms.
+  -->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
+
+<link rel="import" href="spine-abstract-item.html">
+
+
+<!--
+`spine-header-item` can be used inside `paper-listbox` among its children to display a
+non-selectable text that will serve as a heading for the items that follow it in the list.
+
+Here's a list of CSS mixins that can be used for customizing `spine-separator-item`:
+
+Custom property       | Description                  | Default
+----------------------|------------------------------|--------
+`--spine-header-item` | Mixin applied to the element | `{}`
+
+-->
+<dom-module id="spine-header-item">
+  <template>
+    <style>
+      :host {
+        @apply --layout-horizontal;
+        @apply --layout-center;
+
+        min-height: 40px;
+        outline: none;
+        padding: 0 16px;
+
+        @apply --paper-font-caption;
+        color: var(--light-theme-secondary-color);
+
+        @apply --spine-header-item;
+      }
+    </style>
+
+    <slot></slot>
+  </template>
+
+  <script>
+    class SpineHeaderItem extends SpineAbstractItem {
+      static get is() { return 'spine-header-item'; }
+
+      _getAriaRole() {
+        // as per recommendations here: https://www.w3.org/WAI/tutorials/menus/structure/#label-menus
+        return 'heading';
+      }
+
+      connectedCallback() {
+        super.connectedCallback();
+        this.setAttribute("disabled", "disabled");
+      }
+    }
+
+    window.customElements.define(SpineHeaderItem.is, SpineHeaderItem);
+  </script>
+</dom-module>

--- a/spine-header-item.html
+++ b/spine-header-item.html
@@ -13,9 +13,10 @@
 
 <!--
 `spine-header-item` can be used inside `paper-listbox` among its children to display a
-non-selectable text that will serve as a heading for the items that follow it in the list.
+non-selectable item that will serve as a heading for the items that follow it in the list.
+Similar to `paper-item`, you can place arbitrary content as its child nodes.
 
-Here's a list of CSS mixins that can be used for customizing `spine-separator-item`:
+Here's a list of CSS mixins that can be used for customizing `spine-header-item`:
 
 Custom property       | Description                  | Default
 ----------------------|------------------------------|--------

--- a/spine-item-body.html
+++ b/spine-item-body.html
@@ -1,0 +1,124 @@
+<!--
+  ~ Copyright (c) 2000-2018 TeamDev Ltd. All rights reserved.
+  ~ TeamDev PROPRIETARY and CONFIDENTIAL.
+  ~ Use is subject to license terms.
+  -->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
+
+
+<!--
+`spine-item-body` can be placed into `paper-item` and `spine-link-item` to set up a typical item
+layout, where you can specify a multi line content as well as custom content on item's sides
+(typically displaying items).
+
+A component has two slots:
+- `before`: can be used to place a custom content in a left side of the item;
+- `after`: can be used to place a custom content in a right side of the item.
+
+You can place several child elements, which will distribute them vertically inside an item's area.
+Specifying a `secondary` attribute for any of these elements will apply the "secondary" text style
+(having a gray color by default) to the respective element.
+
+Example:
+```
+<paper-listbox>
+  <paper-item on-tap="handleCreateItemTap">
+    <spine-item-body>
+      <iron-icon slot="before" icon="custom:create_item"></iron-icon>
+      Create item...
+    <spine-item-body>
+  </paper-item>
+
+  <spine-link-item href="/settings">
+    <spine-item-body>
+      <iron-icon slot="before" icon="custom:settings"></iron-icon>
+      <div>Settings</div>
+      <div secondary>Displays general settings</div>
+    </spine-item-body>
+  </spine-link-item>
+
+  <spine-link-item href="/notifications">
+    <spine-item-body>
+      <iron-icon slot="before" icon="custom:notifications"></iron-icon>
+      <div>Notifications</div>
+      <div slot="after">
+        [[noOfNotifications]]
+      </div>
+    </spine-item-body>
+  </spine-link-item>
+</paper-listbox>
+```
+
+Here's a list of CSS mixins that can be used for customizing `spine-item-body`:
+
+Custom property                 | Description                                             | Default
+--------------------------------|---------------------------------------------------------|----------
+`--spine-item-body-main-cell`   | Mixin applied to a cell that contains the the elements placed into `spine-item-body` | `{}`
+`--spine-item-body-before-cell` | Mixin applied to a cell that contains the `before` slot | `{}`
+`--spine-item-body-after-cell`  | Mixin applied to a cell that contains the `after` slot  | `{}`
+
+-->
+<dom-module id="spine-item-body">
+  <template>
+    <style>
+      :host {
+        @apply --layout-flex-auto;
+        @apply --layout-self-stretch;
+
+        @apply --layout-horizontal;
+        @apply --layout-center;
+
+        color: inherit;
+        text-decoration: inherit;
+        min-width: 0;
+      }
+
+      .before-cell, .after-cell {
+        flex: none;
+
+        @apply --layout-horizontal;
+        @apply --layout-center;
+        @apply --layout-center-justified;
+      }
+      .before-cell {
+        @apply --spine-item-body-before-cell;
+      }
+      .after-cell {
+        @apply --spine-item-body-after-cell;
+      }
+
+      .main-cell {
+        @apply --layout-flex-auto;
+        @apply --layout-center-justified;
+        @apply --layout-vertical;
+        min-width: 0;
+        align-items: stretch;
+
+        @apply --spine-item-body-main-cell;
+      }
+
+      :host > div > ::slotted([secondary]) {
+        @apply --paper-font-body1;
+        color: var(--secondary-text-color);
+
+        @apply --spine-item-body-secondary;
+        text-overflow: ellipsis;
+      }
+    </style>
+
+    <div class="before-cell"><slot name="before"></slot></div>
+    <div class="main-cell"><slot></slot></div>
+    <div class="after-cell"><slot name="after"></slot></div>
+  </template>
+
+  <script>
+    class SpineItemBody extends Polymer.Element {
+      static get is() { return 'spine-item-body'; }
+    }
+
+    window.customElements.define(SpineItemBody.is, SpineItemBody);
+  </script>
+</dom-module>

--- a/spine-link-item.html
+++ b/spine-link-item.html
@@ -1,0 +1,175 @@
+<!--
+  ~ Copyright (c) 2000-2018 TeamDev Ltd. All rights reserved.
+  ~ TeamDev PROPRIETARY and CONFIDENTIAL.
+  ~ Use is subject to license terms.
+  -->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
+
+<link rel="import" href="spine-abstract-item.html">
+
+
+<!--
+`spine-link-item` can be placed into `paper-listbox` to display an item that navigates to the
+specified URL when it is clicked or tapped.
+
+Example:
+```
+<paper-listbox>
+  <spine-link-item href="/settings">
+    Settings
+  </spine-link-item>
+  <spine-link-item href="/settings/notifications">
+    Notifications
+  </proljwc-link-item>
+  <spine-link-item href="/settings/security">
+    Security
+  </proljwc-link-item>
+</paper-listbox>
+```
+
+### Differences from `paper-item`
+
+Elements placed in `spine-link-item` are laid out with a horizontal flow layout by default.
+You can change this using the `--spine-link-item-content-container` mixin.
+
+The focused, selected and hovered states result in a `::before` pseudo element to be included, which
+is laid out to fill the entire element under the `spine-link-item`'s content. You can use the
+`--spine-link-item-hovered-before`,
+`--spine-link-item-selected-before`, and `--spine-link-item-focused-before` CSS variables to
+highlight the background in these states.
+
+Here's a list of CSS variables and mixins for customizing `spine-link-item`:
+
+Custom property                       | Description                                   | Default
+--------------------------------------|-----------------------------------------------|----------
+`--spine-link-item`                   | Mixin applied to `spine-link-item`            | `{}`
+`--spine-link-item-content-container` | Mixin applied to the item's content container | `{}`
+`--spine-link-item-min-height`        | Minimum height for the item                   | `48px`
+`--spine-link-item-disabled`          | Mixin applied to the item when it is disabled | `{}`
+`--spine-link-item-hovered`           | Mixin applied to the item when it is hovered  | `{}`
+`--spine-link-item-hovered-before`    | Mixin for hovered item's background layer     | `{}`
+`--spine-link-item-selected`          | Mixin applied to the item when it is selected | `{}`
+`--spine-link-item-selected-before`   | Mixin for elected item's background layer     | `{}`
+`--spine-link-item-focused`           | Mixin applied to the item when it is focused  | `{}`
+`--spine-link-item-focused-before`    | Mixin for focused item's background layer     | `{}`
+
+-->
+<dom-module id="spine-link-item">
+  <template>
+    <style>
+      :host {
+        @apply --layout-horizontal;
+        @apply --layout-center;
+        @apply --paper-font-subhead;
+
+        padding: 0 16px;
+        position: relative; /* needed for the absolutely-positioned ::after pseudo-element to be
+                               displayed properly */
+        min-height: var(--spine-link-item-min-height, 48px);
+
+        @apply --spine-link-item;
+      }
+      :host([disabled]) {
+        @apply --spine-link-item-disabled;
+      }
+      :host(:hover) {
+        @apply --spine-link-item-hovered;
+      }
+      :host(.iron-selected) {
+        font-weight: var(--spine-link-item-selected-weight, bold);
+
+        @apply --spine-link-item-selected;
+      }
+      :host(:focus) {
+        outline: none;
+
+        @apply --spine-link-item-focused;
+      }
+
+      :host(:hover)::before, :host(:focus)::before, :host(.iron-selected)::before {
+        @apply --layout-fit;
+        background: currentColor;
+        pointer-events: none;
+        content: '';
+        opacity: 0;
+      }
+      :host(:hover)::before {
+        @apply --spine-link-item-hovered-before;
+      }
+      :host(.iron-selected)::before {
+        @apply --spine-link-item-selected-before;
+      }
+      :host(:focus)::before {
+        opacity: var(--dark-divider-opacity, 0.12);
+
+        @apply --spine-link-item-focused-before;
+      }
+
+      a {
+        width: 0;
+        height: 0;
+        font-size: 0;
+        pointer-events: none;
+        flex: none;
+      }
+      a:focus {
+        outline: none;
+      }
+
+      .content-container {
+        @apply --layout-horizontal;
+        @apply --layout-center;
+        position: relative;
+        width: 100%;
+
+        @apply --spine-link-item-content-container;
+      }
+    </style>
+
+    <a tabindex="-1" href="[[href]]"></a>
+    <!-- Having this content container element serves the purpose of ensuring that the ::before
+         psuedo element that displays a selection/hover/focus layer is displayed under the content
+         rather than over it. Displaying it over the content would make the custom white-colored (or
+         other bright-colored) content to be dimmed when an item is highlighted during hover,
+         selection, or focus when using background filled highlighting for these states. -->
+    <div class="content-container"><slot></slot></div>
+  </template>
+
+  <script>
+    class SpineLinkItem extends SpineAbstractItem {
+      static get is() { return 'spine-link-item'; }
+
+      static get properties() {
+        return {
+          /**
+           * A URL that should be opened when this item is selected.
+           */
+          href: String,
+        };
+      }
+
+      connectedCallback() {
+        super.connectedCallback();
+        this.addEventListener('tap', this._handleTap);
+      }
+
+      disconnectedCallback() {
+        super.disconnectedCallback();
+        this.removeEventListener('tap', this._handleTap);
+      }
+
+      _handleTap(event) {
+        const link = this.shadowRoot.querySelector('a');
+        if (link === null) {
+          return;
+        }
+        link.click();
+      }
+    }
+
+    window.customElements.define(SpineLinkItem.is, SpineLinkItem);
+  </script>
+</dom-module>

--- a/spine-link-item.html
+++ b/spine-link-item.html
@@ -13,7 +13,8 @@
 
 <!--
 `spine-link-item` can be placed into `paper-listbox` to display an item that navigates to the
-specified URL when it is clicked or tapped.
+specified URL when it is clicked or tapped. Use the `href` attribute to specify the URL that should
+be navigated to when this item is clicked or tapped.
 
 Example:
 ```
@@ -29,8 +30,6 @@ Example:
   </proljwc-link-item>
 </paper-listbox>
 ```
-
-### Differences from `paper-item`
 
 Elements placed in `spine-link-item` are laid out with a horizontal flow layout by default.
 You can change this using the `--spine-link-item-content-container` mixin.

--- a/spine-separator-item.html
+++ b/spine-separator-item.html
@@ -1,0 +1,62 @@
+<!--
+  ~ Copyright (c) 2000-2018 TeamDev Ltd. All rights reserved.
+  ~ TeamDev PROPRIETARY and CONFIDENTIAL.
+  ~ Use is subject to license terms.
+  -->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
+
+<link rel="import" href="spine-abstract-item.html">
+
+
+<!--
+`spine-separator-item` can be used inside `paper-listbox` among its children to separate them into
+logical groups.
+
+Here's a list of CSS variables that can be used for customizing `spine-separator-item`:
+
+Custom property                       | Description                                                              | Default
+--------------------------------------|--------------------------------------------------------------------------|----------
+`--spine-separator-item-vert-padding` | A distance from the separator line to the element's top and bottom edges | `8px`
+`--spine-separator-item-line`         | A CSS border-like declaration that identifies the separator line's style, e.g. `1px dotted gray` | `1px solid var(--light-theme-divider-color)`
+
+-->
+<dom-module id="spine-separator-item">
+  <template>
+    <style>
+      :host {
+        @apply --layout-horizontal;
+        @apply --layout-center;
+      }
+      .separator-line {
+        width: 100%;
+        height: 0;
+        border-bottom: var(--spine-separator-item-line, 1px solid var(--light-theme-divider-color, rgba(0, 0, 0, 0.12)));
+        margin-top: var(--spine-separator-item-vert-padding, 8px);
+        margin-bottom: var(--spine-separator-item-vert-padding, 8px);
+      }
+    </style>
+
+    <div class="separator-line"></div>
+  </template>
+
+  <script>
+    class SpineSeparatorItem extends SpineAbstractItem {
+      static get is() { return 'spine-separator-item'; }
+
+      _getAriaRole() {
+        return 'separator';
+      }
+
+      connectedCallback() {
+        super.connectedCallback();
+        this.removeAttribute('tabindex');
+        this.setAttribute('disabled', 'disabled');
+      }
+    }
+
+    window.customElements.define(SpineSeparatorItem.is, SpineSeparatorItem);
+  </script>
+</dom-module>

--- a/spine-separator-item.html
+++ b/spine-separator-item.html
@@ -13,7 +13,8 @@
 
 <!--
 `spine-separator-item` can be used inside `paper-listbox` among its children to separate them into
-logical groups.
+logical groups. It is a non-selectable item that displays a horizontal line whose style can be
+customized.
 
 Here's a list of CSS variables that can be used for customizing `spine-separator-item`:
 

--- a/test/spine-header-item_test.html
+++ b/test/spine-header-item_test.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<!--
+  ~ Copyright (c) 2000-2018 TeamDev Ltd. All rights reserved.
+  ~ TeamDev PROPRIETARY and CONFIDENTIAL.
+  ~ Use is subject to license terms.
+  -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>spine-header-item test</title>
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+
+  <link rel="import" href="testing-utils.html">
+  <link rel="import" href="../spine-header-item.html">
+
+  <style>
+    body {
+      margin: 0;
+      font-family: Roboto, Noto, sans-serif;
+    }
+  </style>
+</head>
+<body>
+<test-fixture id="header-item">
+  <template>
+    <spine-header-item>Header text</spine-header-item>
+  </template>
+</test-fixture>
+
+<script>
+  suite('<spine-header-item>', function() {
+
+    test('basic attributes are correct', () => {
+      const headerItem = fixture('header-item');
+      assert.equal(headerItem.getAttribute('role'), 'heading');
+      assert.equal(headerItem.getAttribute('tabindex'), '-1');
+      assert.isTrue(headerItem.getAttribute('disabled') != null);
+      assert.equal(headerItem.getAttribute('aria-disabled'), 'true');
+    });
+
+    test('text content is correct', () => {
+      const headerItem = fixture('header-item');
+      const slot = headerItem.shadowRoot.querySelector('slot');
+      const assignedNodes = slot.assignedNodes();
+      assert.equal(assignedNodes.length, 1);
+      const slotContent = assignedNodes[0];
+      assert.equal(slotContent.nodeName, _NodeNames.TEXT);
+      assert.equal(slotContent.data.trim(), 'Header text');
+    });
+  });
+</script>
+</body>
+</html>

--- a/test/spine-item-body_test.html
+++ b/test/spine-item-body_test.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<!--
+  ~ Copyright (c) 2000-2018 TeamDev Ltd. All rights reserved.
+  ~ TeamDev PROPRIETARY and CONFIDENTIAL.
+  ~ Use is subject to license terms.
+  -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>spine-item-body test</title>
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+
+  <link rel="import" href="testing-utils.html">
+  <link rel="import" href="../spine-item-body.html">
+
+  <custom-style>
+    <style is="custom-style" include="demo-pages-shared-styles">
+      body {
+        margin: 0;
+        font-family: Roboto, Noto, sans-serif;
+        --secondary-text-color: rgba(1, 2, 3, 0.5);
+      }
+    </style>
+  </custom-style>
+</head>
+<body>
+<test-fixture id="primary-and-secondary">
+  <template>
+    <spine-item-body>
+      Primary text
+      <div secondary>Secondary text</div>
+    </spine-item-body>
+  </template>
+</test-fixture>
+
+
+<test-fixture id="both-slots-specified">
+  <template>
+    <spine-item-body primary-text="Primary text" secondary-text="Secondary text">
+      Primary text
+      <div secondary>Secondary text</div>
+      <div slot="before" class="before-element">"before" slot</div>
+      <div slot="after" class="after-element">"after" slot</div>
+    </spine-item-body>
+  </template>
+</test-fixture>
+
+
+<script>
+  suite('<spine-item-body>', function () {
+
+    function assertSlotContent(itemBody, slotContainerSelector, expectedNodeCheckers, message) {
+      const beforeSlot = itemBody.shadowRoot
+        .querySelector(slotContainerSelector)
+        .querySelector('slot');
+      const slotNodes = beforeSlot.assignedNodes();
+      _checkNodeList(slotNodes, expectedNodeCheckers, message);
+    }
+
+    test('slot content is rendered correctly', done => {
+      const noSlotsItem = fixture('primary-and-secondary');
+      const bothSlotsItem = fixture('both-slots-specified');
+      flush(() => {
+        const beforeSlotSelector = '.before-cell';
+        const mainSlotSelector = '.main-cell';
+        const afterSlotSelector = '.after-cell';
+
+        assertSlotContent(bothSlotsItem, beforeSlotSelector,
+          [_checkers.element({name : 'div', className : 'before-element', innerHTML : '"before" slot'})],
+          'Checking a non-empty "before" slot');
+        assertSlotContent(bothSlotsItem, mainSlotSelector,
+          [
+            _checkers.textNode('Primary text'),
+            _checkers.element({name : 'div', className : null, innerHTML : 'Secondary text'})
+          ], 'Checking main slot content');
+        assertSlotContent(bothSlotsItem, afterSlotSelector,
+          [_checkers.element({name : 'div', className : 'after-element', innerHTML : '"after" slot'})],
+          'Checking a non-empty "after" slot');
+
+        assertSlotContent(noSlotsItem, beforeSlotSelector, null, 'Checking an empty "before" slot');
+        assertSlotContent(bothSlotsItem, mainSlotSelector,
+          [
+            _checkers.textNode('Primary text'),
+            _checkers.element({name : 'div', className : null, innerHTML : 'Secondary text'})
+          ], 'Checking main slot content');
+        assertSlotContent(noSlotsItem, afterSlotSelector, null, 'Checking an empty "after" slot');
+
+        done();
+      });
+    });
+
+    test('secondary content color is correct', () => {
+      const bothSlotsItem = fixture('both-slots-specified');
+      const secondaryContent = bothSlotsItem.querySelector('*[secondary]');
+      _checkers.element({
+        computedStyle : {
+          color : 'rgba(1, 2, 3, 0.5)'
+        }
+      })(secondaryContent, 'Checking secondary content color');
+    });
+
+  });
+</script>
+</body>
+</html>

--- a/test/spine-link-item_test.html
+++ b/test/spine-link-item_test.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<!--
+  ~ Copyright (c) 2000-2018 TeamDev Ltd. All rights reserved.
+  ~ TeamDev PROPRIETARY and CONFIDENTIAL.
+  ~ Use is subject to license terms.
+  -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>spine-link-item test</title>
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+
+  <link rel="import" href="testing-utils.html">
+  <link rel="import" href="../spine-link-item.html">
+
+  <custom-style>
+    <style is="custom-style" include="demo-pages-shared-styles">
+    body {
+      margin: 0;
+      font-family: Roboto, Noto, sans-serif;
+      --light-theme-secondary-color: rgba(1, 2, 3, 0.5);
+    }
+    </style>
+  </custom-style>
+</head>
+<body>
+<test-fixture id="link-item">
+  <template>
+    <spine-link-item href="somePage.html">
+      <div class="custom">Some text</div>
+    </spine-link-item>
+  </template>
+</test-fixture>
+
+
+<script>
+  suite('<spine-link-item>', function() {
+
+    test('basic attributes are correct', () => {
+      const linkItem = fixture('link-item');
+      assert.equal(linkItem.getAttribute('role'), 'option');
+      assert.equal(linkItem.getAttribute('tabindex'), '0');
+      assert.isTrue(linkItem.getAttribute('disabled') === null);
+      assert.equal(linkItem.getAttribute('aria-disabled'), 'false');
+
+      const link = linkItem.shadowRoot.querySelector("a");
+      assert.equal(link.getAttribute('tabindex'), '-1');
+      assert.equal(link.getAttribute('href'), 'somePage.html');
+    });
+
+    test('slot content is rendered correctly', done => {
+      const linkItem = fixture('link-item');
+      flush(() => {
+        const slotNodes = linkItem.shadowRoot.querySelector('slot').assignedNodes();
+        _checkNodeList(slotNodes, [
+          _checkers.element({name : 'div', className : 'custom', innerHTML : 'Some text'})
+        ]);
+        done();
+      });
+    });
+
+  });
+</script>
+</body>
+</html>

--- a/test/spine-separator-item_test.html
+++ b/test/spine-separator-item_test.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<!--
+  ~ Copyright (c) 2000-2018 TeamDev Ltd. All rights reserved.
+  ~ TeamDev PROPRIETARY and CONFIDENTIAL.
+  ~ Use is subject to license terms.
+  -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>spine-separator-item test</title>
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+
+  <link rel="import" href="../spine-separator-item.html">
+
+  <style>
+    body {
+      margin: 0;
+      font-family: Roboto, Noto, sans-serif;
+    }
+    .customized-separator {
+      --spine-separator-item-vert-padding: 4px;
+      --spine-separator-item-line: 2px solid gray;
+    }
+  </style>
+</head>
+<body>
+<test-fixture id="default-separator">
+  <template>
+    <spine-separator-item></spine-separator-item>
+  </template>
+</test-fixture>
+
+<test-fixture id="customized-separator">
+  <template>
+    <spine-separator-item class="customized-separator"></spine-separator-item>
+  </template>
+</test-fixture>
+
+<script>
+  suite('<spine-separator-item>', function() {
+    const defaultVertPadding = 8;
+    const defaultLinewidth = 1;
+
+    test('basic attributes are correct', () => {
+      const defaultSeparator = fixture('default-separator');
+      assert.equal(defaultSeparator.getAttribute('role'), 'separator');
+      assert.equal(defaultSeparator.getAttribute('tabindex'), '-1');
+      assert.isTrue(defaultSeparator.getAttribute('disabled') != null);
+      assert.equal(defaultSeparator.getAttribute('aria-disabled'), 'true');
+    });
+
+    test('default height is correct', () => {
+      const defaultSeparator = fixture('default-separator');
+      assert.equal(defaultSeparator.offsetHeight, defaultVertPadding * 2 + defaultLinewidth);
+    });
+
+    test('customized height is correct', () => {
+      const defaultSeparator = fixture('customized-separator');
+      const customizedVertPadding = 4;
+      const customizedLinewidth = 2;
+      assert.equal(defaultSeparator.offsetHeight, customizedVertPadding * 2 + customizedLinewidth);
+    });
+  });
+</script>
+</body>
+</html>

--- a/test/testing-utils.html
+++ b/test/testing-utils.html
@@ -1,0 +1,141 @@
+<!--
+  ~ Copyright (c) 2000-2018 TeamDev Ltd. All rights reserved.
+  ~ TeamDev PROPRIETARY and CONFIDENTIAL.
+  ~ Use is subject to license terms.
+  -->
+
+<link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
+
+<!--
+  Provides the utility functions for testing. These are considered private to this package and
+  shouldn't be used by those who import it to just use its elements.
+-->
+<script>
+  /**
+   * Contains constants for the standard node names
+   * (https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeName).
+   *
+   * This member is considered private to the package. Please don't use it if you're just importing
+   * the package to use its elements.
+   *
+   * @private
+   */
+  window._NodeNames = {
+    TEXT: '#text',
+    COMMENT: '#comment'
+  };
+
+  /**
+   * Checks the list of elements using the list of checkers — one checker for each node.
+   *
+   * A "checker" here is a function that accepts two parameters (`node: Node`, `message: string`),
+   * and runs assertions for any criteria that the respective node should fulfill. If the passed
+   * node passes all checks then the checker function should return without exceptions.
+   * messages. Checker implementations are encouraged to include the `message` passed to them into
+   * the actual assertion messages so that a higher level assertion context is clear in the
+   * resulting messages.
+   *
+   * This member is considered private to the package. Please don't use it if you're just importing
+   * the package to use its elements.
+   *
+   * @private
+   */
+  window._checkNodeList = function(nodes, expectedNodeCheckers, message) {
+    const messagePrefix = message ? `${message}: ` : '';
+    if (!expectedNodeCheckers) {
+      assert.equal(nodes.length, 0, `${messagePrefix}expecting nodes list to be empty.`);
+      return;
+    }
+    const nonEmptyNodes = Array.from(nodes).filter(node =>
+        node.nodeName !== _NodeNames.TEXT || node.data.trim() !== ''
+    );
+    assert.equal(nonEmptyNodes.length, expectedNodeCheckers.length,
+        `${messagePrefix}checking the number of nodes`);
+    nonEmptyNodes
+    .forEach((node, index)=> {
+      const expectedNodeChecker = expectedNodeCheckers[index];
+      expectedNodeChecker(node, `${messagePrefix}checking node number #{index}`);
+    });
+  };
+
+  /**
+   * A collection of functions that create and return checkers of various kinds.
+   *
+   * A "checker" here is a function that accepts two parameters (`node: Node`, `message: string`),
+   * and checks the specified node for any criteria that are specific for this type of checker using
+   * the assertion functions. So if element checking fails, an appropriate assertion exception is
+   * thrown, and if all checks are passed then the function returns without exceptions. The
+   * `message` parameter provides a text that should be included into the actual assertion
+   * messages.
+   *
+   * This member is considered private to the package. Please don't use it if you're just importing
+   * the package to use its elements.
+   *
+   * @private
+   */
+  window._checkers = {
+    /**
+     * Creates a checker that checks whether a node that it is given is an element that that
+     * satisfies the criteria passed in the `params` argument.
+     *
+     * @param {{
+     *    name: string|undefined,
+     *    className: string|undefined,
+     *    innerHTML: string|undefined,
+     *    nodeCheckers: Array<function>|undefined,
+     *    computedStyle: Object|undefined
+     *  }} params
+     * @returns {function(node: Node, message: string)}
+     *
+     * This member is considered private to the package. Please don't use it if you're just importing
+     * the package to use its elements.
+     *
+     * @private
+     */
+    element: (params) => (node, message) => {
+      assert.isTrue(node instanceof Element, `${message}. Checking that the passed node is ` +
+          `instance of Element (node.nodeName = '${node.nodeName}'`);
+      if (params.name !== undefined) {
+        assert.equal(node.tagName.toLowerCase(), params.name,
+            `${message}: expecting a <div> node inside a slot.`);
+      }
+      if (params.className !== undefined) {
+        assert.equal(node.className || '', params.className || '',
+            `${message}: checking element's class name.`);
+      }
+      if (params.innerHTML !== undefined) {
+        assert.equal(node.innerHTML.trim(), params.innerHTML,
+            `${message}: checking element's innerHTML.`);
+      }
+      if (params.nodeCheckers !== undefined) {
+        _checkNodeList(node.childNodes, params.nodeCheckers, `${message}: checking child nodes`);
+      }
+      if (params.computedStyle !== undefined) {
+        const style = getComputedStyle(node);
+        Object.keys(params.computedStyle).forEach(propertyName => {
+          assert.equal(style[propertyName], params.computedStyle[propertyName],
+              `${message}: checkig CSS property named '${propertyName}'`);
+        });
+      }
+    },
+
+    /**
+     * Creates a checker that ensures that the passed node is a text node with the specified text.
+     *
+     * @param {string} text
+     * @returns {function(node: Node, message: string)}
+     *
+     * This member is considered private to the package. Please don't use it if you're just importing
+     * the package to use its elements.
+     *
+     * @private
+     */
+    textNode: text => (node, message) => {
+      assert.equal(node.nodeName, _NodeNames.TEXT, `Expecting a text node (with text "${text}"), ` +
+          `but encountered a node named ${node.nodeName}`);
+      const trimmedText = node.data.trim();
+      assert.equal(trimmedText, text, `${message}: checking the text node's content`);
+    }
+  };
+
+</script>

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -1,0 +1,3 @@
+{
+  "suites": ["test/**/*_test.html"]
+}


### PR DESCRIPTION
Contains the following elements `spine-header-item`, `spine-link-item`, `spine-separator-item`, `spine-item-body`.

All of the custom item elements are placed in the same package due to the following considerations:
- they constitute a family of related elements with similar usage scenarios (e.g. using them inside of `paper-listbox`);
- the set of features that each of them introduces is relatively simple;
- there are some standard polymer packages that follow a similar pattern of having several related elements inside: [`paper-tabs`](https://github.com/PolymerElements/paper-tabs), [`app-layout`](https://github.com/PolymerElements/app-layout), [`paper-item`](https://github.com/PolymerElements/paper-item).