### PR TITLE
Minor styling and documentation amendments

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ Similar to `paper-item`, you can place arbitrary content as its child nodes.
 
 Here's a list of CSS mixins that can be used for customizing `spine-header-item`:
 
-Custom property       | Description                  | Default
-----------------------|------------------------------|--------
-`--spine-header-item` | Mixin applied to the element | `{}`
+Custom property                  | Description                  | Default
+---------------------------------|------------------------------|--------
+`--spine-header-item`            | Mixin applied to the element | `{}`
+`--spine-header-item-min-height` | Minimum height for the item  | `32px`
+`--secondary-text-color`         | The default text color       | `rgba(0, 0, 0, var(--dark-secondary-opacity, 0.54))`
 
 ## `spine-link-item`
 
@@ -52,11 +54,13 @@ You can change this using the `--spine-link-item-content-container` mixin.
 
 The focused, selected and hovered states result in a `::before` pseudo element to be included, which
 is laid out to fill the entire element under the `spine-link-item`'s content. You can use the
-`--spine-link-item-hovered-before`,
-`--spine-link-item-selected-before`, and `--spine-link-item-focused-before` CSS variables to
-highlight the background in these states.
+`--spine-link-item-hovered-before`, `--spine-link-item-selected-before`, and
+`--spine-link-item-focused-before` CSS variables to highlight the background in these states. Note
+that by default the background of the `::before` pseudo element is set to `currentColor` and
+`opacity` attribute is used for setting the intensity of the background color.
 
-Here's a list of CSS variables and mixins for customizing `spine-link-item`:
+Below is a list of CSS variables and mixins for customizing `spine-link-item`. A "background layer"
+mentioned below refers to the `::before` pseudo element mentioned above.
 
 Custom property                       | Description                                   | Default
 --------------------------------------|-----------------------------------------------|----------
@@ -67,14 +71,16 @@ Custom property                       | Description                             
 `--spine-link-item-hovered`           | Mixin applied to the item when it is hovered  | `{}`
 `--spine-link-item-hovered-before`    | Mixin for hovered item's background layer     | `{}`
 `--spine-link-item-selected`          | Mixin applied to the item when it is selected | `{}`
-`--spine-link-item-selected-before`   | Mixin for elected item's background layer     | `{}`
+`--spine-link-item-selected-before`   | Mixin for selected item's background layer    | `{}`
 `--spine-link-item-focused`           | Mixin applied to the item when it is focused  | `{}`
 `--spine-link-item-focused-before`    | Mixin for focused item's background layer     | `{}`
+`--dark-divider-opacity`              | Default opacity of a focused background (applied to the background layer) | `0.12`
+`--disabled-text-color`               | Default text color for a disabled item        | `{rgba(0, 0, 0, var(--dark-disabled-opacity, 0.38))}`
 
 ## `spine-separator-item`
 
 `spine-separator-item` can be used inside `paper-listbox` among its children to separate them into
-logical groups. It is a non-selectable item that displays a horizontal line whose style can be 
+logical groups. It is a non-selectable item that displays a horizontal line whose style can be
 customized.
 
 Here's a list of CSS variables that can be used for customizing `spine-separator-item`:
@@ -82,7 +88,7 @@ Here's a list of CSS variables that can be used for customizing `spine-separator
 Custom property                       | Description                                                              | Default
 --------------------------------------|--------------------------------------------------------------------------|----------
 `--spine-separator-item-vert-padding` | A distance from the separator line to the element's top and bottom edges | `8px`
-`--spine-separator-item-line`         | A CSS border-like declaration that identifies the separator line's style, e.g. `1px dotted gray` | `1px solid var(--light-theme-divider-color)`
+`--spine-separator-item-line`         | A CSS border-like declaration that identifies the separator line's style, e.g. `1px dotted gray` | `1px solid var(--divider-color, rgba(0, 0, 0, var(--dark-divider-opacity, 0.12)))`
 
 ## `spine-item-body`
 
@@ -135,6 +141,8 @@ Custom property                 | Description                                   
 `--spine-item-body-main-cell`   | Mixin applied to a cell that contains the the elements placed into `spine-item-body` | `{}`
 `--spine-item-body-before-cell` | Mixin applied to a cell that contains the `before` slot | `{}`
 `--spine-item-body-after-cell`  | Mixin applied to a cell that contains the `after` slot  | `{}`
+`--paper-font-body1`            | Style applied to the secondary element(s) by default    | `{}`
+`--secondary-text-color`        | Text color set for secondary element(s) by default      | `rgba(0, 0, 0, var(--dark-secondary-opacity, 0.54))`
 
 # License
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -85,6 +85,12 @@
             spine-badge
           </spine-item-body>
         </spine-link-item>
+        <spine-link-item href="https://github.com/SpineElements/some-disabled-item" disabled>
+          <spine-item-body>
+            <iron-icon slot="before" icon="star"></iron-icon>
+            some-disabled-item
+          </spine-item-body>
+        </spine-link-item>
 
       </paper-listbox>
     </template>

--- a/spine-header-item.html
+++ b/spine-header-item.html
@@ -18,9 +18,10 @@ Similar to `paper-item`, you can place arbitrary content as its child nodes.
 
 Here's a list of CSS mixins that can be used for customizing `spine-header-item`:
 
-Custom property       | Description                  | Default
-----------------------|------------------------------|--------
-`--spine-header-item` | Mixin applied to the element | `{}`
+Custom property                  | Description                  | Default
+---------------------------------|------------------------------|--------
+`--spine-header-item`            | Mixin applied to the element | `{}`
+`--spine-header-item-min-height` | Minimum height for the item  | `32px`
 
 -->
 <dom-module id="spine-header-item">
@@ -30,7 +31,7 @@ Custom property       | Description                  | Default
         @apply --layout-horizontal;
         @apply --layout-center;
 
-        min-height: 40px;
+        min-height: var(--spine-header-item-min-height, 32px);
         outline: none;
         padding: 0 16px;
 

--- a/spine-header-item.html
+++ b/spine-header-item.html
@@ -22,6 +22,7 @@ Custom property                  | Description                  | Default
 ---------------------------------|------------------------------|--------
 `--spine-header-item`            | Mixin applied to the element | `{}`
 `--spine-header-item-min-height` | Minimum height for the item  | `32px`
+`--secondary-text-color`         | The default text color       | `rgba(0, 0, 0, var(--dark-secondary-opacity, 0.54))`
 
 -->
 <dom-module id="spine-header-item">
@@ -36,7 +37,7 @@ Custom property                  | Description                  | Default
         padding: 0 16px;
 
         @apply --paper-font-caption;
-        color: var(--light-theme-secondary-color);
+        color: var(--secondary-text-color, rgba(0, 0, 0, var(--dark-secondary-opacity, 0.54)));
 
         @apply --spine-header-item;
       }

--- a/spine-item-body.html
+++ b/spine-item-body.html
@@ -59,6 +59,8 @@ Custom property                 | Description                                   
 `--spine-item-body-main-cell`   | Mixin applied to a cell that contains the the elements placed into `spine-item-body` | `{}`
 `--spine-item-body-before-cell` | Mixin applied to a cell that contains the `before` slot | `{}`
 `--spine-item-body-after-cell`  | Mixin applied to a cell that contains the `after` slot  | `{}`
+`--paper-font-body1`            | Style applied to the secondary element(s) by default    | `{}`
+`--secondary-text-color`        | Text color set for secondary element(s) by default      | `rgba(0, 0, 0, var(--dark-secondary-opacity, 0.54))`
 
 -->
 <dom-module id="spine-item-body">
@@ -102,7 +104,7 @@ Custom property                 | Description                                   
 
       :host > div > ::slotted([secondary]) {
         @apply --paper-font-body1;
-        color: var(--secondary-text-color);
+        color: var(--secondary-text-color, rgba(0, 0, 0, var(--dark-secondary-opacity, 0.54)));
 
         @apply --spine-item-body-secondary;
         text-overflow: ellipsis;

--- a/spine-link-item.html
+++ b/spine-link-item.html
@@ -36,11 +36,13 @@ You can change this using the `--spine-link-item-content-container` mixin.
 
 The focused, selected and hovered states result in a `::before` pseudo element to be included, which
 is laid out to fill the entire element under the `spine-link-item`'s content. You can use the
-`--spine-link-item-hovered-before`,
-`--spine-link-item-selected-before`, and `--spine-link-item-focused-before` CSS variables to
-highlight the background in these states.
+`--spine-link-item-hovered-before`, `--spine-link-item-selected-before`, and
+`--spine-link-item-focused-before` CSS variables to highlight the background in these states. Note
+that by default the background of the `::before` pseudo element is set to `currentColor` and
+`opacity` attribute is used for setting the intensity of the background color.
 
-Here's a list of CSS variables and mixins for customizing `spine-link-item`:
+Below is a list of CSS variables and mixins for customizing `spine-link-item`. A "background layer"
+mentioned below refers to the `::before` pseudo element mentioned above.
 
 Custom property                       | Description                                   | Default
 --------------------------------------|-----------------------------------------------|----------
@@ -51,9 +53,11 @@ Custom property                       | Description                             
 `--spine-link-item-hovered`           | Mixin applied to the item when it is hovered  | `{}`
 `--spine-link-item-hovered-before`    | Mixin for hovered item's background layer     | `{}`
 `--spine-link-item-selected`          | Mixin applied to the item when it is selected | `{}`
-`--spine-link-item-selected-before`   | Mixin for elected item's background layer     | `{}`
+`--spine-link-item-selected-before`   | Mixin for selected item's background layer    | `{}`
 `--spine-link-item-focused`           | Mixin applied to the item when it is focused  | `{}`
 `--spine-link-item-focused-before`    | Mixin for focused item's background layer     | `{}`
+`--dark-divider-opacity`              | Default opacity of a focused background (applied to the background layer) | `0.12`
+`--disabled-text-color`               | Default text color for a disabled item        | `{rgba(0, 0, 0, var(--dark-disabled-opacity, 0.38))}`
 
 -->
 <dom-module id="spine-link-item">
@@ -72,6 +76,8 @@ Custom property                       | Description                             
         @apply --spine-link-item;
       }
       :host([disabled]) {
+        color: var(--disabled-text-color, rgba(0, 0, 0, var(--dark-disabled-opacity, 0.38)));
+
         @apply --spine-link-item-disabled;
       }
       :host(:hover) {

--- a/spine-separator-item.html
+++ b/spine-separator-item.html
@@ -21,7 +21,7 @@ Here's a list of CSS variables that can be used for customizing `spine-separator
 Custom property                       | Description                                                              | Default
 --------------------------------------|--------------------------------------------------------------------------|----------
 `--spine-separator-item-vert-padding` | A distance from the separator line to the element's top and bottom edges | `8px`
-`--spine-separator-item-line`         | A CSS border-like declaration that identifies the separator line's style, e.g. `1px dotted gray` | `1px solid var(--light-theme-divider-color)`
+`--spine-separator-item-line`         | A CSS border-like declaration that identifies the separator line's style, e.g. `1px dotted gray` | `1px solid var(--divider-color, rgba(0, 0, 0, var(--dark-divider-opacity, 0.12)))`
 
 -->
 <dom-module id="spine-separator-item">
@@ -34,7 +34,7 @@ Custom property                       | Description                             
       .separator-line {
         width: 100%;
         height: 0;
-        border-bottom: var(--spine-separator-item-line, 1px solid var(--light-theme-divider-color, rgba(0, 0, 0, 0.12)));
+        border-bottom: var(--spine-separator-item-line, 1px solid var(--divider-color, rgba(0, 0, 0, var(--dark-divider-opacity, 0.12))));
         margin-top: var(--spine-separator-item-vert-padding, 8px);
         margin-bottom: var(--spine-separator-item-vert-padding, 8px);
       }


### PR DESCRIPTION
Includes the following:
- a new CSS variable for `spine-header-item`'s minimum height; 
- changed a default min height from 40px to 32px, which seems to
be more common;
- documented and corrected the usage of standard CSS mixins and variables.