### PR TITLE
Make some minor default style corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Here's a list of CSS mixins that can be used for customizing `spine-header-item`
 Custom property                  | Description                       | Default
 ---------------------------------|-----------------------------------|--------
 `--spine-header-item`            | Mixin applied to the element      | `{}`
-`--spine-header-item-min-height` | Minimum height for the item       | `32px`
-`--paper-font-caption`           | Applied to the element by default | `{}`
+`--spine-header-item-min-height` | Minimum height for the item       | `40px`
+`--paper-font-body2`             | Applied to the element by default | `{}`
 `--secondary-text-color`         | The default text color            | `rgba(0, 0, 0, var(--dark-secondary-opacity, 0.54))`
 
 ## `spine-link-item`

--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ Similar to `paper-item`, you can place arbitrary content as its child nodes.
 
 Here's a list of CSS mixins that can be used for customizing `spine-header-item`:
 
-Custom property                  | Description                  | Default
----------------------------------|------------------------------|--------
-`--spine-header-item`            | Mixin applied to the element | `{}`
-`--spine-header-item-min-height` | Minimum height for the item  | `32px`
-`--secondary-text-color`         | The default text color       | `rgba(0, 0, 0, var(--dark-secondary-opacity, 0.54))`
+Custom property                  | Description                       | Default
+---------------------------------|-----------------------------------|--------
+`--spine-header-item`            | Mixin applied to the element      | `{}`
+`--spine-header-item-min-height` | Minimum height for the item       | `32px`
+`--paper-font-caption`           | Applied to the element by default | `{}`
+`--secondary-text-color`         | The default text color            | `rgba(0, 0, 0, var(--dark-secondary-opacity, 0.54))`
 
 ## `spine-link-item`
 
@@ -74,6 +75,7 @@ Custom property                       | Description                             
 `--spine-link-item-selected-before`   | Mixin for selected item's background layer    | `{}`
 `--spine-link-item-focused`           | Mixin applied to the item when it is focused  | `{}`
 `--spine-link-item-focused-before`    | Mixin for focused item's background layer     | `{}`
+`--paper-font-subhead`                | Applied to the item by default                | `{}`
 `--dark-divider-opacity`              | Default opacity of a focused background (applied to the background layer) | `0.12`
 `--disabled-text-color`               | Default text color for a disabled item        | `{rgba(0, 0, 0, var(--dark-disabled-opacity, 0.38))}`
 

--- a/bower.json
+++ b/bower.json
@@ -23,9 +23,10 @@
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",
     "web-component-tester": "Polymer/web-component-tester#^6.5.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0",
-    "paper-listbox": "^2.1.0",
     "iron-icon": "^2.1.0",
-    "iron-icons": "^2.1.1"
+    "iron-icons": "^2.1.1",
+    "paper-styles": "^2.1.0",
+    "paper-listbox": "^2.1.0"
   },
   "resolutions": {
     "polymer": "^2.0.0"

--- a/demo/index.html
+++ b/demo/index.html
@@ -12,6 +12,7 @@
   <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
   <link rel="import" href="../../iron-icons/iron-icons.html">
   <link rel="import" href="../../iron-icon/iron-icon.html">
+  <link rel="import" href="../../paper-styles/typography.html">
   <link rel="import" href="../../paper-listbox/paper-listbox.html">
   <link rel="import" href="../spine-header-item.html">
   <link rel="import" href="../spine-link-item.html">

--- a/spine-header-item.html
+++ b/spine-header-item.html
@@ -21,8 +21,8 @@ Here's a list of CSS mixins that can be used for customizing `spine-header-item`
 Custom property                  | Description                       | Default
 ---------------------------------|-----------------------------------|--------
 `--spine-header-item`            | Mixin applied to the element      | `{}`
-`--spine-header-item-min-height` | Minimum height for the item       | `32px`
-`--paper-font-caption`           | Applied to the element by default | `{}`
+`--spine-header-item-min-height` | Minimum height for the item       | `40px`
+`--paper-font-body2`             | Applied to the element by default | `{}`
 `--secondary-text-color`         | The default text color            | `rgba(0, 0, 0, var(--dark-secondary-opacity, 0.54))`
 
 -->
@@ -33,11 +33,11 @@ Custom property                  | Description                       | Default
         @apply --layout-horizontal;
         @apply --layout-center;
 
-        min-height: var(--spine-header-item-min-height, 32px);
+        min-height: var(--spine-header-item-min-height, 40px);
         outline: none;
         padding: 0 16px;
 
-        @apply --paper-font-caption;
+        @apply --paper-font-body2;
         color: var(--secondary-text-color, rgba(0, 0, 0, var(--dark-secondary-opacity, 0.54)));
 
         @apply --spine-header-item;

--- a/spine-header-item.html
+++ b/spine-header-item.html
@@ -18,11 +18,12 @@ Similar to `paper-item`, you can place arbitrary content as its child nodes.
 
 Here's a list of CSS mixins that can be used for customizing `spine-header-item`:
 
-Custom property                  | Description                  | Default
----------------------------------|------------------------------|--------
-`--spine-header-item`            | Mixin applied to the element | `{}`
-`--spine-header-item-min-height` | Minimum height for the item  | `32px`
-`--secondary-text-color`         | The default text color       | `rgba(0, 0, 0, var(--dark-secondary-opacity, 0.54))`
+Custom property                  | Description                       | Default
+---------------------------------|-----------------------------------|--------
+`--spine-header-item`            | Mixin applied to the element      | `{}`
+`--spine-header-item-min-height` | Minimum height for the item       | `32px`
+`--paper-font-caption`           | Applied to the element by default | `{}`
+`--secondary-text-color`         | The default text color            | `rgba(0, 0, 0, var(--dark-secondary-opacity, 0.54))`
 
 -->
 <dom-module id="spine-header-item">

--- a/spine-link-item.html
+++ b/spine-link-item.html
@@ -56,6 +56,7 @@ Custom property                       | Description                             
 `--spine-link-item-selected-before`   | Mixin for selected item's background layer    | `{}`
 `--spine-link-item-focused`           | Mixin applied to the item when it is focused  | `{}`
 `--spine-link-item-focused-before`    | Mixin for focused item's background layer     | `{}`
+`--paper-font-subhead`                | Applied to the item by default                | `{}`
 `--dark-divider-opacity`              | Default opacity of a focused background (applied to the background layer) | `0.12`
 `--disabled-text-color`               | Default text color for a disabled item        | `{rgba(0, 0, 0, var(--dark-disabled-opacity, 0.38))}`
 
@@ -72,6 +73,7 @@ Custom property                       | Description                             
         position: relative; /* needed for the absolutely-positioned ::after pseudo-element to be
                                displayed properly */
         min-height: var(--spine-link-item-min-height, 48px);
+        cursor: pointer;
 
         @apply --spine-link-item;
       }


### PR DESCRIPTION
- Added the `pointer` cursor for `spine-link-item`. Having a `pointer` cursor by default seems appropriate for a link item.
- Made the default `spine-header-item`'s style more consistent with others.
- Described the usage of some previously unmentioned standard CSS mixins.