### PR TITLE
Fix `spine-item-link`'s Firefox navigation issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: node
+node_js: lts/*
 
 # work around a Chrome startup crash issue:
 #   https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356339798

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,11 @@ node_js: lts/*
 #   https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356339798
 #   https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356362524
 sudo: required
+
 addons:
   firefox: latest
+  chrome: stable
+
 before_script:
 - npm install -g polymer-cli
 - polymer install

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ Example:
   </spine-link-item>
   <spine-link-item href="/settings/notifications">
     Notifications
-  </proljwc-link-item>
+  </spine-link-item>
   <spine-link-item href="/settings/security">
     Security
-  </proljwc-link-item>
+  </spine-link-item>
 </paper-listbox>
 ```
 

--- a/bower.json
+++ b/bower.json
@@ -19,14 +19,17 @@
     "iron-behaviors": "^2.1.1"
   },
   "devDependencies": {
-    "iron-doc-viewer": "PolymerElements/iron-doc-viewer#^2.0.0",
-    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",
     "web-component-tester": "Polymer/web-component-tester#^6.5.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0",
+    "iron-doc-viewer": "PolymerElements/iron-doc-viewer#^2.0.0",
+    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",
     "iron-icon": "^2.1.0",
     "iron-icons": "^2.1.1",
+    "iron-test-helpers": "^2.0.0",
+    "app-route": "PolymerElements/app-route#2.1.1",
     "paper-styles": "^2.1.0",
-    "paper-listbox": "^2.1.0"
+    "paper-listbox": "^2.1.0",
+    "spine-test-helpers": "SpineElements/spine-test-helpers#^0.2.1"
   },
   "resolutions": {
     "polymer": "^2.0.0"

--- a/spine-link-item.html
+++ b/spine-link-item.html
@@ -24,10 +24,10 @@ Example:
   </spine-link-item>
   <spine-link-item href="/settings/notifications">
     Notifications
-  </proljwc-link-item>
+  </spine-link-item>
   <spine-link-item href="/settings/security">
     Security
-  </proljwc-link-item>
+  </spine-link-item>
 </paper-listbox>
 ```
 
@@ -138,7 +138,7 @@ Custom property                       | Description                             
 
     <a tabindex="-1" href="[[href]]"></a>
     <!-- Having this content container element serves the purpose of ensuring that the ::before
-         psuedo element that displays a selection/hover/focus layer is displayed under the content
+         pseudo element that displays a selection/hover/focus layer is displayed under the content
          rather than over it. Displaying it over the content would make the custom white-colored (or
          other bright-colored) content to be dimmed when an item is highlighted during hover,
          selection, or focus when using background filled highlighting for these states. -->
@@ -169,11 +169,35 @@ Custom property                       | Description                             
       }
 
       _handleTap(event) {
+        if (this.__customEvent) {
+          // dispatching `click` event manually below in this method is reintercepted as a `tap`
+          // event by this element, so we're ignoring it here to avoid infinite recursion
+          return;
+        }
         const link = this.shadowRoot.querySelector('a');
         if (link === null) {
           return;
         }
-        link.click();
+
+        if (!window.ShadyDOM || !window.ShadyDOM.inUse) {
+          link.click();
+        } else {
+          // Not invoking the `link.click()` as in a regular case above, since a `click` event
+          // emitted by that call doesn't cross the shadow DOM boundary in Firefox (as of version
+          // 59.0.3), presumably due to some ShadyDOM polyfill implementation specifics. This causes
+          // problems when `iron-location` (or `app-location`) tries to prevent page reloads on link
+          // clicks. Firing the `click` event manually solves this problem.
+          this.__customEvent = new MouseEvent('click', {
+            bubbles: true,
+            composed: true,
+            cancelable: true
+          });
+          try {
+            link.dispatchEvent(this.__customEvent);
+          } finally {
+            this.__customEvent = null;
+          }
+        }
       }
     }
 

--- a/test/spine-link-item_test.html
+++ b/test/spine-link-item_test.html
@@ -12,6 +12,9 @@
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
 
+  <link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
+  <link rel="import" href="../../spine-test-helpers/spine-test-helpers.html">
+  <link rel="import" href="../../app-route/app-location.html">
   <link rel="import" href="testing-utils.html">
   <link rel="import" href="../spine-link-item.html">
 
@@ -33,10 +36,27 @@
     </spine-link-item>
   </template>
 </test-fixture>
+<test-fixture id="cooperation-with-app-location">
+  <template>
+    <div>
+      <app-location></app-location>
+      <spine-link-item href="somePage1.html">
+        <div class="custom">Link item 1</div>
+      </spine-link-item>
+      <spine-link-item href="somePage2.html">
+        <div class="custom">Link item 2</div>
+      </spine-link-item>
+    </div>
+  </template>
+</test-fixture>
 
 
 <script>
   suite('<spine-link-item>', function() {
+
+    function clickItem(itemElement) {
+      MockInteractions.keyDownOn(itemElement, 13);
+    }
 
     test('basic attributes are correct', () => {
       const linkItem = fixture('link-item');
@@ -58,6 +78,47 @@
           _checkers.element({name : 'div', className : 'custom', innerHTML : 'Some text'})
         ]);
         done();
+      });
+    });
+
+    test('works with app-location correctly', done => {
+      const testFixture = fixture('cooperation-with-app-location');
+      flush(() => {
+        const linkItems = testFixture.querySelectorAll('spine-link-item');
+        const appLocation = testFixture.querySelector('app-location');
+        assert.equal(linkItems.length, 2, 'expecting two test links');
+        const valueToPreserve = {};
+        linkItems[0].__spineTestValue = valueToPreserve;
+
+        const ensureUrlUpdatedButDocumentRemained = (expectedUrlSuffix, message) => {
+          const expectedRoute = `/components/spine-item-elements/test/${expectedUrlSuffix}`;
+          assert.isTrue(document.location.href.endsWith(expectedRoute),
+              `${message}: document URL should be changed`);
+          assert.equal(appLocation.route.path, expectedRoute,
+              `${message}: checking the route.path property of app-location`);
+          // Ensure that iron-location (used by app-location) prevents default link click actions:
+          // https://github.com/PolymerElements/iron-location/blob/23cbb3dad0ba549033ef6874befd0da5f3878b5f/iron-location.html#L301
+          //
+          // This used to break in Firefox due to `click` events dispatched by `link.click()` calls
+          // not bubbling beyond shadow root, and thus weren't prevented on the document level by
+          // iron-location: https://github.com/TeamDev-Ltd/License-Server/issues/87
+          assert.strictEqual(linkItems[0].__spineTestValue, valueToPreserve,
+              'Document itself shouldn\'t be reloaded');
+        };
+
+        runAsyncChain({interval: 500},
+          () => {
+            clickItem(linkItems[0]);
+          }, () => {
+            ensureUrlUpdatedButDocumentRemained('somePage1.html',
+                'checking navigation using item 1');
+            clickItem(linkItems[1]);
+          }, () => {
+            ensureUrlUpdatedButDocumentRemained('somePage2.html',
+                'checking navigation using item 2');
+            done();
+          }
+        );
       });
     });
 


### PR DESCRIPTION
Includes the following:
1. A fix for a Firefox navigation issue: clicking on `spine-link-item` with `app-location` in use was reloading the page in Firefox (while it should just switch the URL without reloading the page according to `app-location`'s behavior).

   Using `link.click()` for triggering link navigation that was used in `spine-item-link` implementation doesn't play well with functionality of `iron-location` (or `app-location`) where it prevents page reload by  invoking `event.preventDefault()` on a click event dispatched by a link in this case (see [here](https://github.com/PolymerElements/iron-location/blob/23cbb3dad0ba549033ef6874befd0da5f3878b5f/iron-location.html#L301)).

   An event emitted by `link.click()` call doesn't cross the shadow DOM boundary in Firefox though (at least in case of Firefox version 59.0.3), presumably due to some ShadyDOM polyfill implementation specifics.

   The solution implemented here is to dispatch the `click` event manually when ShadyDOM polyfill is in use, which solves this problem.

2. A `.travis.yml` update to address build failure.